### PR TITLE
Don't override default bottledwater options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,6 @@ RUN apk add --no-cache --virtual .build-deps \
     rm -rf /tmp/bottledwater
 
 ENTRYPOINT ["/usr/local/bin/bottledwater-docker-wrapper.sh"]
-CMD ["--output-format=avro", "--allow-unkeyed"]
 
 LABEL maintainer="King Chung Huang <kchuang@ucalgary.ca>" \
 	  org.label-schema.schema-version="1.0" \


### PR DESCRIPTION
Remove the CMD instruction in the Dockerfile. It specifies the
`--output-format` and `--allowed-unkeyed` options, making those two options
impossible to override by environment variables, only.