### PR TITLE
Remove setting of --schema-registry based on host entry

### DIFF
--- a/build/bottledwater-docker-wrapper.sh
+++ b/build/bottledwater-docker-wrapper.sh
@@ -30,14 +30,6 @@ for var in "${!BOTTLED_WATER_@}"; do
   esac
 done
 
-# do we have a link to the schema-registry container?
-if getent hosts schema-registry >/dev/null; then
-  SCHEMA_REGISTRY_URL="http://schema-registry:8081"
-
-  log "Detected schema registry, setting --schema-registry=$SCHEMA_REGISTRY_URL"
-  bw_opts+=(--schema-registry="$SCHEMA_REGISTRY_URL")
-fi
-
 BOTTLEDWATER=/usr/local/bin/bottledwater
 VALGRIND=/usr/bin/valgrind
 


### PR DESCRIPTION
Stop setting the --schema-registry option on bottledwater based on the
presence of a host entry for schema-registry. Setting --schema-registry
in this way makes it impossible to run bottledwater with json output
where a schema-registry is available.

If a schema registry is required, it should be explicitly set with the
---schema-registry option.

Resolves #13.